### PR TITLE
made work with more recent cryptocipher

### DIFF
--- a/Data/OpenPGP/CryptoAPI.hs
+++ b/Data/OpenPGP/CryptoAPI.hs
@@ -5,8 +5,8 @@ import Data.Word
 import Data.Char
 import Data.Bits
 import Data.List (find)
-import Data.Binary
-import Crypto.Classes hiding (hash,sign,verify)
+import Data.Binary 
+import Crypto.Classes hiding (hash,sign,verify, encode)
 import Crypto.Random (CryptoRandomGen)
 import Crypto.Hash.MD5 (MD5)
 import Crypto.Hash.SHA1 (SHA1)
@@ -93,7 +93,7 @@ keyParam c k = fromJustMPI $ lookup c (OpenPGP.key k)
 privateRSAkey :: OpenPGP.Packet -> RSA.PrivateKey
 privateRSAkey k =
 	-- Invert p and q because u is pinv not qinv
-	RSA.PrivateKey (integerBytesize n) n d q p
+	RSA.PrivateKey pubkey d q p
 		(d `mod` (q-1))
 		(d `mod` (p-1))
 		(keyParam 'u' k)
@@ -102,7 +102,8 @@ privateRSAkey k =
 	p = keyParam 'p' k
 	q = keyParam 'q' k
 	n = keyParam 'n' k
-
+        pubkey = rsaKey k
+        
 rsaKey :: OpenPGP.Packet -> RSA.PublicKey
 rsaKey k =
 	RSA.PublicKey (integerBytesize n) n (keyParam 'e' k)
@@ -148,7 +149,7 @@ verify keys message sigidx =
 	sig = sigs !! sigidx
 	(sigs, (OpenPGP.LiteralDataPacket {OpenPGP.content = dta}):_) =
 		OpenPGP.signatures_and_data message
-
+           
 -- | Sign data or key/userID pair.
 sign :: (CryptoRandomGen g) =>
         OpenPGP.Message    -- ^ SecretKeys, one of which will be used

--- a/openpgp-crypto-api.cabal
+++ b/openpgp-crypto-api.cabal
@@ -1,5 +1,5 @@
 name:            openpgp-crypto-api
-version:         0.3
+version:         0.4
 cabal-version:   >= 1.8
 license:         OtherLicense
 license-file:    COPYING

--- a/openpgp-crypto-api.cabal
+++ b/openpgp-crypto-api.cabal
@@ -49,7 +49,7 @@ library
                 binary,
                 openpgp,
                 crypto-api,
-                cryptocipher,
+                cryptocipher >= 0.3.7,
                 cryptohash,
                 cereal
 
@@ -64,7 +64,7 @@ test-suite tests
                 binary,
                 openpgp,
                 crypto-api >= 0.9,
-                cryptocipher,
+                cryptocipher >= 0.3.7,
                 cryptohash,
                 HUnit,
                 QuickCheck >= 2.4.1.1,

--- a/openpgp-crypto-api.cabal
+++ b/openpgp-crypto-api.cabal
@@ -66,6 +66,7 @@ test-suite tests
                 crypto-api >= 0.9,
                 cryptocipher >= 0.3.7,
                 cryptohash,
+                cereal,
                 HUnit,
                 QuickCheck >= 2.4.1.1,
                 test-framework,


### PR DESCRIPTION
The structure for of the RSA.PrivateKey has changed to aggregate the RSA.PublicKey instead of keeping the parameters themself.

Build and succesfully run tests with cryptocipher v0.3.7
