### PR TITLE
Hide buildKeyGen from Crpto.Classes

### DIFF
--- a/Data/OpenPGP/CryptoAPI.hs
+++ b/Data/OpenPGP/CryptoAPI.hs
@@ -10,7 +10,7 @@ import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State (StateT(..), runStateT)
 import Data.Binary (encode, decode, get, Word16)
-import Crypto.Classes hiding (cfb,unCfb,sign,verify,encode)
+import Crypto.Classes hiding (cfb,unCfb,sign,verify,encode,buildKeyGen)
 import Data.Tagged (untag, asTaggedTypeOf, Tagged(..))
 import Crypto.Modes (cfb, unCfb, zeroIV)
 import Crypto.Types (IV)


### PR DESCRIPTION
I'm getting this error when I try to install the package.

```
Data/OpenPGP/CryptoAPI.hs:360:22:
    Ambiguous occurrence `buildKeyGen'
    It could refer to either `Data.OpenPGP.CryptoAPI.buildKeyGen',
                             defined at Data/OpenPGP/CryptoAPI.hs:45:1
                          or `Crypto.Classes.buildKeyGen',
                             imported from `Crypto.Classes' at Data/OpenPGP/CryptoAPI.hs:13:1-59

Data/OpenPGP/CryptoAPI.hs:364:22:
    Ambiguous occurrence `buildKeyGen'
    It could refer to either `Data.OpenPGP.CryptoAPI.buildKeyGen',
                             defined at Data/OpenPGP/CryptoAPI.hs:45:1
                          or `Crypto.Classes.buildKeyGen',
                             imported from `Crypto.Classes' at Data/OpenPGP/CryptoAPI.hs:13:1-59

Data/OpenPGP/CryptoAPI.hs:368:22:
    Ambiguous occurrence `buildKeyGen'
    It could refer to either `Data.OpenPGP.CryptoAPI.buildKeyGen',
                             defined at Data/OpenPGP/CryptoAPI.hs:45:1
                          or `Crypto.Classes.buildKeyGen',
                             imported from `Crypto.Classes' at Data/OpenPGP/CryptoAPI.hs:13:1-59

Data/OpenPGP/CryptoAPI.hs:372:22:
    Ambiguous occurrence `buildKeyGen'
    It could refer to either `Data.OpenPGP.CryptoAPI.buildKeyGen',
                             defined at Data/OpenPGP/CryptoAPI.hs:45:1
                          or `Crypto.Classes.buildKeyGen',
                             imported from `Crypto.Classes' at Data/OpenPGP/CryptoAPI.hs:13:1-59
Failed to install openpgp-crypto-api-0.6.2
```
